### PR TITLE
Feature/41 goal post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 
 # Storybook build output
 storybook-static/
+/src/app/goal/detail/page.tsx

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ src/
 │   ├── favicon.ico                # 사이트 파비콘
 │   ├── layout.tsx                 # 전역 레이아웃 관리
 │   ├── loading.tsx                # 전역 로딩 페이지
-│   └── page.tsx                   # 홈페이지
+│   └── default.tsx                   # 홈페이지
 ├── assets/                        # 이미지, 폰트, 아이콘 등 정적 리소스
 ├── components/                    # UI 컴포넌트
 │   ├── common/                    # 공통적으로 사용되는 UI 컴포넌트

--- a/src/app/goal/detail/@modal/default.tsx
+++ b/src/app/goal/detail/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null
+}

--- a/src/app/goal/detail/@modal/goal-modal/goalmodal.module.scss
+++ b/src/app/goal/detail/@modal/goal-modal/goalmodal.module.scss
@@ -1,0 +1,46 @@
+.upload {
+  padding-top: 20px;
+  border-top: 1px solid #D9D9D9;
+}
+.uploadtitle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 30px;
+  h3 {
+    font-size: 20px;
+    font-weight: 700;
+  }
+  p {
+    color: $gray-80;
+    font-size: 18px;
+  }
+}
+
+.uploadimage {
+  padding: 20px 30px;
+  span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #F2F2F5;
+    width: 240px;
+    height: 240px;
+    color: #727793;
+    border-radius: 6px;
+  }
+  label {
+    display: inline-block;
+    width: 240px;
+    height: 240px;
+    background-size: cover;
+    border-radius: 6px;
+  }
+  input {
+    display: none;
+  }
+}
+
+.upload-btn {
+  padding: 0 30px;
+}

--- a/src/app/goal/detail/@modal/goal-modal/page.tsx
+++ b/src/app/goal/detail/@modal/goal-modal/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+import BottomSheet from "@/components/common/buttomsheet/bottomsheet";
+import { useRouter } from "next/navigation";
+import SmallCalendar from "@/components/common/smallcalendar/smallcalendar";
+import styles from "./goalmodal.module.scss"
+import React, {useState} from "react";
+import Button from "@/components/common/button/button";
+
+const GoalModal = () => {
+  const router = useRouter();
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setImagePreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const closeModal = () => {
+    router.back();
+  };
+
+  return (
+    <BottomSheet close={closeModal} title={"목표인증샷"}>
+      <SmallCalendar />
+      <div className={styles.upload}>
+        <div className={styles.uploadtitle}>
+          <h3>20분동안 걷기</h3>
+          <p>0/3회 인증</p>
+        </div>
+        <div className={styles.uploadimage}>
+          <input
+            id={"image-upload"}
+            type="file"
+            accept="image/*"
+            onChange={handleImageChange}
+          />
+          <label
+            htmlFor={"image-upload"}
+            style={{
+              backgroundImage: imagePreview
+                ? `url(${imagePreview})`
+                : "none",
+            }}
+          >
+            {!imagePreview && (
+              <span>사진첨부</span>
+            )}
+          </label>
+        </div>
+      </div>
+      <div className={styles["upload-btn"]}>
+        <Button size={"medium"} variant={"filled"} shape={"rounded"} label={"확인"} onClick={() => {}} />
+      </div>
+    </BottomSheet>
+  )
+}
+export default GoalModal;

--- a/src/app/goal/detail/detail.module.scss
+++ b/src/app/goal/detail/detail.module.scss
@@ -1,5 +1,4 @@
 .goal {
-    padding-top: 52px;
     &__content {
       background: url("../../../assets/imgs/goals/bg-goaldetail.png") center / cover;
       padding-bottom: 100px;

--- a/src/app/goal/detail/layout.tsx
+++ b/src/app/goal/detail/layout.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function DetailLayout({ children, modal }: {
+  children: React.ReactNode,
+  modal: React.ReactNode,
+}) {
+  return (
+    <>
+      {modal}
+      {children}
+    </>
+  )
+}

--- a/src/app/goal/detail/page.tsx
+++ b/src/app/goal/detail/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+import styles from "./detail.module.scss";
+
+import Character1 from "@/assets/character/step1.svg";
+import SmallCalendar from "@/components/common/smallcalendar/smallcalendar";
+import StepBox from "@/components/features/goal/stepbox/stepbox";
+import {useRouter} from "next/navigation";
+import TopSheet from "@/components/common/topsheet/topsheet";
+
+
+
+const Page = () => {
+  const router = useRouter();
+  const openModal = () => {
+    router.push('/goal/detail/goal-modal');
+  }
+  return (
+    <>
+      <div className={styles.goal}>
+        <div className={styles.goal__content}>
+          <div className={styles.goal__calendar}>
+            <TopSheet>
+              <SmallCalendar />
+            </TopSheet>
+          </div>
+
+          <div className={styles.goal__character}>
+            <Character1/>
+          </div>
+
+          <div className={styles.goal__profile} onClick={openModal}>
+            <span>1월 24일 ~ 1월 31일 목표</span>
+            <span>한 주 동안 레벨 업! 더 가볍고 건강하게!</span>
+            <p>0/5개 달성</p>
+          </div>
+
+          <div className={styles.goal__box}>
+            <StepBox/>
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/goal/goal.module.scss
+++ b/src/app/goal/goal.module.scss
@@ -1,5 +1,4 @@
 .goal {
-  padding-top: 52px;
   &__content {
     background-color: #97D3F7;
     min-height: 100vh;

--- a/src/app/goal/layout.module.scss
+++ b/src/app/goal/layout.module.scss
@@ -2,6 +2,6 @@
   font-size: 1.6rem;
   min-height: 100vh;
   > div {
-    padding-top: 52px;
+    margin-top: 52px;
   }
 }

--- a/src/app/goal/layout.tsx
+++ b/src/app/goal/layout.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import Navigation from "@/components/layout/Navigation";
-import classNames from "classnames/bind";
 import styles from "./layout.module.scss";
 import DefaultHeader from "@/components/layout/header/DefaultHeader";
-const cx = classNames.bind(styles);
-
-export default function GoalLayout ({ children }: { children: React.ReactNode }) {
+interface GoalLayoutProps {
+  children: React.ReactNode;
+}
+export default function GoalLayout ({ children }: GoalLayoutProps) {
   return (
     <>
       <DefaultHeader/>
       <div>
-        <main className={cx("goal")}>
+        <main className={styles.goal}>
           {children}
         </main>
         <Navigation/>

--- a/src/app/goal/layout.tsx
+++ b/src/app/goal/layout.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import Navigation from "@/components/layout/Navigation";
 import classNames from "classnames/bind";
 import styles from "./layout.module.scss";
+import DefaultHeader from "@/components/layout/header/DefaultHeader";
 const cx = classNames.bind(styles);
 
 export default function GoalLayout ({ children }: { children: React.ReactNode }) {
   return (
+    <>
+      <DefaultHeader/>
       <div>
         <main className={cx("goal")}>
           {children}
         </main>
-        <Navigation />
+        <Navigation/>
       </div>
+    </>
   );
 }

--- a/src/app/goal/page.tsx
+++ b/src/app/goal/page.tsx
@@ -15,7 +15,6 @@ import DefaultHeader from "@/components/layout/header/DefaultHeader";
 const Page = () => {
   return (
     <>
-      <DefaultHeader />
       <div className={cx("goal")}>
         <div className={cx("goal__content")}>
           <div className={cx("goal__calendar")}>

--- a/src/app/goal/page.tsx
+++ b/src/app/goal/page.tsx
@@ -10,7 +10,7 @@ import SmallCalendar from "@/components/common/smallcalendar/smallcalendar";
 import GaugeBar from "@/components/common/gaugebar/gaugebar";
 import GaugeDonut from "@/components/common/gaugedonut/gaugedonut";
 import AddButton from "@/components/common/addbutton/addbutton";
-import DefaultHeader from "@/components/layout/header/DefaultHeader";
+import TopSheet from "@/components/common/topsheet/topsheet";
 
 const Page = () => {
   return (
@@ -18,7 +18,9 @@ const Page = () => {
       <div className={cx("goal")}>
         <div className={cx("goal__content")}>
           <div className={cx("goal__calendar")}>
-            <SmallCalendar />
+            <TopSheet>
+              <SmallCalendar />
+            </TopSheet>
           </div>
 
           <div className={cx("goal__character")}>

--- a/src/assets/icons/close.svg
+++ b/src/assets/icons/close.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 8L8 24M24 24L8 8" stroke="#8D8D8D" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/common/buttomsheet/bottomsheet.tsx
+++ b/src/components/common/buttomsheet/bottomsheet.tsx
@@ -1,0 +1,21 @@
+"use client"
+import React from "react";
+import styles from "./buttomsheet.module.scss"
+import {CloseIcon} from "@/components/common/icon";
+const BottomSheet = ({children, close, title} : { children: React.ReactNode }) => {
+  return (
+    <div className={styles.bottomsheet}>
+      <div className={styles.backdrop}></div>
+      <div className={styles.content}>
+        <div className={styles.modalheader}>
+          <span></span>
+          <h2>{title}</h2>
+          <CloseIcon onClick={() => close()} />
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default BottomSheet

--- a/src/components/common/buttomsheet/buttomsheet.module.scss
+++ b/src/components/common/buttomsheet/buttomsheet.module.scss
@@ -1,0 +1,39 @@
+.bottomsheet {
+  position: fixed;
+  bottom: 0;
+  z-index: 999;
+  width: 100%;
+  height: 100%;
+}
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  background: #000;
+  opacity: 0.6;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+}
+.content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 70%;
+  width: 100%;
+  background: #fff;
+  z-index: 1001;
+  border-radius: 30px 30px 0 0;
+  padding: 24px 0 0 0;
+}
+.modalheader {
+  padding: 0 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  h2 {
+    font-size: 20px;
+    font-weight: 700;
+    text-align: center;
+  }
+}

--- a/src/components/common/icon/index.tsx
+++ b/src/components/common/icon/index.tsx
@@ -1,2 +1,3 @@
 export { default as AddBtnIcon } from '@/assets/icons/add_btn.svg';
 export { default as PhotoChangeIcon } from '@/assets/icons/profile.svg';
+export { default as CloseIcon } from '@/assets/icons/close.svg'

--- a/src/components/common/smallcalendar/smallcalendar.module.scss
+++ b/src/components/common/smallcalendar/smallcalendar.module.scss
@@ -1,40 +1,24 @@
 .calendar {
-  height: 215px;
   background-color: #fff;
   border-radius: 0 0 32px 32px;
-  box-shadow: 0 18px 35px 0 rgba(0, 0, 0, 0.1);
   text-align: center;
+
   &-item {
-    h2 {
-      padding-top: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    padding: 24px 30px;
+    font-weight: 700;
+
+    li {
+      font-size: 20px;
       text-align: center;
-      font-size: 24px;
-      font-weight: 700;
-    }
-    ul {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 5px;
-      padding: 24px 30px;
-      font-weight: 700;
 
-      li {
-        font-size: 20px;
-        text-align: center;
-
-        p {
-          margin-top: 5px;
-          padding: 10px;
-        }
+      p {
+        margin-top: 5px;
+        padding: 10px;
       }
     }
-  }
-  &-bar {
-    display: inline-block;
-    width: 78px;
-    height: 6px;
-    background-color: #D8DADB;
-    border-radius: 10px;
   }
 }

--- a/src/components/common/smallcalendar/smallcalendar.tsx
+++ b/src/components/common/smallcalendar/smallcalendar.tsx
@@ -4,42 +4,37 @@ const cx = classNames.bind(styles);
 const SmallCalendar = () => {
   return (
     <div className={cx("calendar")}>
-      <div className={cx("calendar__content")}>
-        <div className={cx("calendar-item")}>
-          <h2>2020. 00</h2>
-          <ul>
-            <li>
-              <p>월</p>
-              <p>24</p>
-            </li>
-            <li>
-              <p>월</p>
-              <p>24</p>
-            </li>
-            <li>
-              <p>월</p>
-              <p>24</p>
-            </li>
-            <li>
-              <p>월</p>
-              <p>24</p>
-            </li>
-            <li>
-              <p>월</p>
-              <p>24</p>
-            </li>
-            <li>
-              <p>월</p>
-              <p>24</p>
-            </li>
-            <li>
-              <p>월</p>
-              <p>24</p>
-            </li>
-          </ul>
-          <span className={cx("calendar-bar")}></span>
-        </div>
-      </div>
+      <ul className={cx("calendar-item")}>
+        <li>
+          <p>월</p>
+          <p>24</p>
+        </li>
+        <li>
+          <p>월</p>
+          <p>24</p>
+        </li>
+        <li>
+          <p>월</p>
+          <p>24</p>
+        </li>
+        <li>
+          <p>월</p>
+          <p>24</p>
+        </li>
+        <li>
+          <p>월</p>
+          <p>24</p>
+        </li>
+        <li>
+          <p>월</p>
+          <p>24</p>
+        </li>
+        <li>
+          <p>월</p>
+          <p>24</p>
+        </li>
+      </ul>
+      <span className={cx("calendar-bar")}></span>
     </div>
   )
 }

--- a/src/components/common/topsheet/topsheet.module.scss
+++ b/src/components/common/topsheet/topsheet.module.scss
@@ -1,0 +1,20 @@
+.topsheet {
+  background: #fff;
+  border-radius: 0 0 32px 32px;
+  box-shadow: 0 18px 35px 0 rgba(0, 0, 0, 0.1);
+  text-align: center;
+  padding-bottom: 10px;
+  h2 {
+    padding-top: 26px;
+    text-align: center;
+    font-size: 24px;
+    font-weight: 700;
+  }
+  &-bar {
+    display: inline-block;
+    width: 78px;
+    height: 6px;
+    background-color: #D8DADB;
+    border-radius: 10px;
+  }
+}

--- a/src/components/common/topsheet/topsheet.tsx
+++ b/src/components/common/topsheet/topsheet.tsx
@@ -1,0 +1,15 @@
+import classNames from "classnames/bind";
+import styles from "./topsheet.module.scss";
+const cx = classNames.bind(styles);
+const TopSheet = ({ children }) => {
+  return (
+    <div className={cx("topsheet")}>
+      <div className={cx("topsheet__content")}>
+        <h2>2020. 00</h2>
+        {children}
+        <span className={cx("topsheet-bar")}></span>
+      </div>
+    </div>
+  )
+}
+export default TopSheet;

--- a/src/components/layout/header/DefaultHeader.module.scss
+++ b/src/components/layout/header/DefaultHeader.module.scss
@@ -1,5 +1,6 @@
 .header {
   position: fixed;
+  top: 0;
   width: 100%;
   max-width: 769px;
   box-sizing: border-box;


### PR DESCRIPTION
## 추가사항
1. 모달 컴포넌트
2. 목표 인증샷 페이지 레이아웃 추가
3. topsheet 컴포넌트분리

## nextjs의 병렬 경로를 이용한 모달창 구현
이번에는 처음으로 Next.js의 병렬 경로(Parallel Routes) 기능을 이용해 모달창을 만들어봤는데, 전통적인 createPortal 방식과 다르게 많은 장점이있다는걸 발견해서 공유드려요

병렬 경로는 페이지 기반의 모달을 구성할 수 있어서, 사용자가 URL로 직접 접근하거나 뒤로 가기 버튼으로 자연스럽게 모달을 닫을 수 있습니다. 덕분에 모달이 단순한 레이어가 아니라 앱 흐름의 일부처럼 동작해요.

1. 모달이 열린 상태의 URL을 공유할 수 있음

2. 브라우저의 뒤로 가기 버튼으로 닫을 수 있음
**이거 너무 큰 장점인거 같아요!!!!** 안드로이드 기기에서 사용자는 뒤로가기 버튼을 눌러 모달을 닫는 UX에 익숙하다고 하더라고요. 저도 이전에는 이걸 지원하기 위해 별도로 useBackButtonClose 같은 커스텀 훅을 만들어 관리했어요. 하지만 이번에 Next.js의 병렬 경로 기반 모달을 적용하면서 이 모든 게 router.back() 하나로 해결됐습니다.

3. 기존 화면은 그대로 유지되면서, 모달만 겹쳐지는 경험 제공

전통적인 방식의 모달이 특정 UI 안에서만 동작하는 비공식적인 상태라면, 병렬 경로 기반 모달은 앱의 공식적인 한 부분처럼 정식 루트로 편입된 상태에 더 가깝다고 느꼈어요.
이전보다 더 접근성 좋고, UX도 유연한 모달 경험을 만들 수 있었던 점이 특히 인상 깊었습니다.

## 방법
별건 없구요, next가 다 해주네요 폴더 구조만 잘 잡으면 됩니다! (근데 저는 사실 구조파악이 처음에 잘 안돼서 쫌 헤맸어요..)

```
src/
└── app/
    └── goal/
        └── detail/
            ├── layout.tsx           // DetailLayout
            ├── page.tsx             // Detail 메인 페이지
            └── @modal/              // 병렬 라우트 슬롯 (@modal)
                ├── goal-modal/
                │   └── page.tsx     // goal-modal용 모달 컴포넌트
                └── default.tsx      // 필수: @modal 슬롯의 기본 렌더링
```

                 
[Parallel Routes](https://nextjs.org/docs/app/building-your-application/routing/parallel-routes)

## 관련 이슈 (Related Issues)
- Related to #40 